### PR TITLE
Demo

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,31 @@
+name: Build and Publish
+
+on:
+  pull_request:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4 # v4.2.2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4 # v4.3.1
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build solution
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Publish to GitHub Packages
+      run: |
+        dotnet nuget add source --username sincejune --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/sincejune/index.json"
+        dotnet pack --configuration Release || true
+        dotnet nuget push 'src/OpenTelemetry.Instrumentation.SqlClient/bin/Release/OpenTelemetry.Instrumentation.SqlClient.0.0.0-alpha.0.nupkg' --source github

--- a/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Rec
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForText.get -> bool
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForText.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SqlClientTraceInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.ContextPropagationLevel.get -> string!
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.ContextPropagationLevel.set -> void
 OpenTelemetry.Metrics.SqlClientMeterProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Metrics.SqlClientMeterProviderBuilderExtensions.AddSqlClientInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlCommenter.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlCommenter.cs
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+
+namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+using System.Collections.Generic;
+
+internal sealed class SqlCommenter
+{
+    public static string EncodeParams(Dictionary<string, string> parameters)
+    {
+        List<string> encodedParams = new List<string>();
+
+        foreach (var kvp in parameters)
+        {
+            string? encodedKey = WebUtility.UrlEncode(kvp.Key);
+            string? encodedValue = WebUtility.UrlEncode(kvp.Value);
+            encodedParams.Add($"{encodedKey}='{encodedValue}'");
+        }
+
+        return string.Join(",", encodedParams);
+    }
+
+    public static string CreateComment(string encodedParams)
+    {
+        if (string.IsNullOrEmpty(encodedParams))
+        {
+            return string.Empty; // Or "/* */"
+        }
+
+        return $"/*{encodedParams}*/";
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
@@ -18,6 +18,16 @@ namespace OpenTelemetry.Instrumentation.SqlClient;
 public class SqlClientTraceInstrumentationOptions
 {
     /// <summary>
+    /// Flag to send traceparent information to SQL Server.
+    /// </summary>
+    internal const string ContextPropagationLevelTrace = "trace";
+
+    /// <summary>
+    /// Flag to disable sending trace information to SQL Server.
+    /// </summary>
+    internal const string ContextPropagationDisabled = "disabled";
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SqlClientTraceInstrumentationOptions"/> class.
     /// </summary>
     public SqlClientTraceInstrumentationOptions()
@@ -30,6 +40,7 @@ public class SqlClientTraceInstrumentationOptions
         var databaseSemanticConvention = GetSemanticConventionOptIn(configuration);
         this.EmitOldAttributes = databaseSemanticConvention.HasFlag(DatabaseSemanticConvention.Old);
         this.EmitNewAttributes = databaseSemanticConvention.HasFlag(DatabaseSemanticConvention.New);
+        this.ContextPropagationLevel = ContextPropagationDisabled;
     }
 
     /// <summary>
@@ -62,6 +73,24 @@ public class SqlClientTraceInstrumentationOptions
     /// </para>
     /// </remarks>
     public bool SetDbStatementForText { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to send trace information to SQL Server database.
+    /// Optional values:
+    /// <see langword="trace"/>:
+    /// Send traceparent information to SQL Server.
+    /// <see langword="disabled"/>:
+    /// Disable sending trace information to SQL Server.
+    /// Default value: <see landword="disabled"/>.
+    /// </summary>
+    public string ContextPropagationLevel { get; set; }
+
+    /// <summary>
+    /// The service name we will attach to the query via SQL commenter,
+    /// only works when <see cref="ContextPropagationLevel"/> is enabled
+    /// </summary>
+    public string? ServiceName { get; set; }
+
 
     /// <summary>
     /// Gets or sets an action to enrich an <see cref="Activity"/> with the

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -54,6 +54,7 @@ public sealed class SqlClientIntegrationTests : IClassFixture<SqlClientIntegrati
             {
                 options.SetDbStatementForText = captureTextCommandContent;
                 options.RecordException = recordException;
+                options.ContextPropagationLevel = SqlClientTraceInstrumentationOptions.ContextPropagationLevelTrace;
                 if (shouldEnrich)
                 {
                     options.Enrich = SqlClientTests.ActivityEnrichment;


### PR DESCRIPTION
#### Description
* Added supports to set context info in SQL Server.
* Added basic support for sqlcommenter to enrich `service.name`
* This PR will push artifacts to [GitHub Package](https://github.com/dashbase/opentelemetry-dotnet-contrib/pkgs/nuget/OpenTelemetry.Instrumentation.SqlClient)
  * Note that GitHub package doesn't support version override so we need to remove existing versions when releasing.

Limitations
* Currently, it seems hard to retrieve service.name programmatically. This PR added one more option to set it when instrumentating.